### PR TITLE
fix: fix priceInfo 'nil' error on discovery

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -334,7 +334,7 @@ func (orch *orchestrator) priceInfo(sender ethcommon.Address, manifestID Manifes
 
 	basePrice := big.NewRat(0, 1)
 	if caps == nil {
-		if transcodePrice == nil {
+		if transcodePrice != nil {
 			basePrice = transcodePrice
 		}
 	} else {

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -332,12 +332,13 @@ func (orch *orchestrator) priceInfo(sender ethcommon.Address, manifestID Manifes
 		transcodePrice = orch.node.GetBasePrice("default")
 	}
 
-	var basePrice *big.Rat
+	basePrice := big.NewRat(0, 1)
 	if caps == nil {
-		basePrice = transcodePrice
+		if transcodePrice == nil {
+			basePrice = transcodePrice
+		}
 	} else {
 		// The base price is the sum of the prices of individual capability + model ID pairs
-		basePrice = big.NewRat(0, 1)
 		for cap := range caps.Capacities {
 			// If the capability does not have constraints (and thus any model constraints) skip it
 			// because we only price a capability together with a model ID right now
@@ -359,7 +360,7 @@ func (orch *orchestrator) priceInfo(sender ethcommon.Address, manifestID Manifes
 
 		// If no priced capabilities were signaled by the broadcaster assume that they are requesting
 		// transcoding and set the base price to the transcode price
-		if transcodePrice != nil && (basePrice == nil || basePrice.Cmp(big.NewRat(0, 1)) == 0) {
+		if transcodePrice != nil && basePrice.Cmp(big.NewRat(0, 1)) == 0 {
 			basePrice = transcodePrice
 		}
 	}


### PR DESCRIPTION
@eliteprox this pull request fixes a problem that was still in https://github.com/livepeer/go-livepeer/pull/3059 where when a Gateway send a discovery request a `nil` error was thrown.

#### How to reproduce

I think the error is caused by 

1. Checkout https://github.com/livepeer/go-livepeer/pull/3059.
2. Startup the AI orchestrator without the `pricePerUnit` flag.
3. Startup an AI Gateway.
4. Wait till the Gateway sends a request to the `Get
 
